### PR TITLE
introduce ability to provide product amount

### DIFF
--- a/Cart.php
+++ b/Cart.php
@@ -190,7 +190,8 @@ class Cart extends Component
     {
         $sum = 0;
         foreach ($this->getItems($itemType) as $model) {
-            $sum += $model->{$attribute};
+            $qty = in_array("yii2mod\cart\models\CartQuantityItem", class_uses($model) ) ? $model->quantity : 1;
+            $sum += $model->{$attribute} * $qty;
         }
 
         return $sum;

--- a/models/CartQuantityItem.php
+++ b/models/CartQuantityItem.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: franziskakoehn
+ * Date: 15.09.17
+ * Time: 14:33
+ */
+
+namespace yii2mod\cart\models;
+
+
+trait CartQuantityItem
+{
+    public $quantity = 0;
+
+    public function setQuantity($qty){
+        $this->quantity = $qty;
+    }
+
+}


### PR DESCRIPTION
Hi,

our shopping-cart use case also needs an amount for every product of an order. I implemented a very short solution that doesn't touch your cart-implementation (using traits).

usage idea:
the product uses this trait besides implementing your CardItemInterface

```php
class Product extends \yii\db\ActiveRecord implements CartItemInterface
{
    use CartQuantityItem; ... 
```

then the products insert looks like this:

```php
$product->setQuantity($qty);
$cart->add($product);
```

and the view fits easily into the original solution:
```php
echo \yii2mod\cart\widgets\CartGrid::widget([
    // Some widget property maybe need to change.
    'cartColumns' => [
        'id',
        'label',
        'price',
        'quantity'    
],
]);
```
What's your opinion about my approach?