### PR TITLE
deleted types to include non-integer guest session-ids

### DIFF
--- a/storage/DatabaseStorage.php
+++ b/storage/DatabaseStorage.php
@@ -105,7 +105,7 @@ class DatabaseStorage extends Object implements StorageInterface
      *
      * @return int
      */
-    protected function getIdentifier(int $default): int
+    protected function getIdentifier($default)
     {
         $id = $default;
 


### PR DESCRIPTION
Hi,

in order to provide the usage of this shopping-cart for guests, the getIdentifier method needs to accept and return non integer identifiers (=session-ids of guests).