### PR TITLE
changed is_subclass_of to is_a

### DIFF
--- a/Cart.php
+++ b/Cart.php
@@ -170,7 +170,7 @@ class Cart extends Component
                 $items,
                 function ($item) use ($itemType) {
                     /* @var $item CartItemInterface */
-                    return is_subclass_of($item, $itemType);
+                    return is_a($item, $itemType);
                 }
             );
         }


### PR DESCRIPTION
is_a() also returns true when the given item is an instance of the given class, which "is_subclass_of" does not (it also returns true if the given item implements the classname as an interface or inherits of from it). Thus "is_a" satisfies the method description.