### PR TITLE
Fix for Declaration , compatibility .

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ return [
 class ProductModel extends ActiveRecord implements CartItemInterface
 {
 
-    public function getPrice()
+//requires php >= 7, declare version in composer.json
+    public function getPrice() : int
     {
         return $this->price;
     }


### PR DESCRIPTION
Error:
Declaration of app\models\Product::getPrice() must be compatible with yii2mod\cart\models\CartItemInterface::getPrice(): int

return type should be defined to fix the incompatibility. Also, PHP version should be greater than  7 in the composer.json.